### PR TITLE
Remove style key from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/dunovank/jupyterlab_darkside_ui.git"


### PR DESCRIPTION
So the theme doesn't leave some elements styled on the page when switching themes.

![image](https://user-images.githubusercontent.com/591645/124789892-f66f5f00-df4a-11eb-80e2-5899df453aab.png)

Similar to https://github.com/telamonian/theme-darcula/pull/33